### PR TITLE
Improve navigation in submission blueprint

### DIFF
--- a/blueprints/pages/submission.php
+++ b/blueprints/pages/submission.php
@@ -19,6 +19,10 @@ return function () {
 
 	return [
 		'title' => 'dreamform.submission',
+		'navigation' => [
+			'status' => 'all',
+			'sortBy' => 'sortDate desc'
+		],
 		'image' => [
 			'icon' => 'archive',
 			'back' => '#fafafa',

--- a/snippets/fields/textarea.php
+++ b/snippets/fields/textarea.php
@@ -15,7 +15,7 @@ $attr = A::merge($attr, $attr['textarea']);
 snippet('dreamform/fields/partials/wrapper', $arguments = compact('block', 'field', 'form', 'attr'), slots: true);
 snippet('dreamform/fields/partials/label', $arguments); ?>
 
-<textarea <?= attr(A::merge($attr['input'], [
+<textarea <?= attr(A::merge($attr['textarea'], [
 	'id' => $block->id(),
 	'name' => $block->key(),
 	'placeholder' => $block->placeholder()->or(" "),

--- a/snippets/fields/textarea.php
+++ b/snippets/fields/textarea.php
@@ -15,7 +15,7 @@ $attr = A::merge($attr, $attr['textarea']);
 snippet('dreamform/fields/partials/wrapper', $arguments = compact('block', 'field', 'form', 'attr'), slots: true);
 snippet('dreamform/fields/partials/label', $arguments); ?>
 
-<textarea <?= attr(A::merge($attr['textarea'], [
+<textarea <?= attr(A::merge($attr['input'], [
 	'id' => $block->id(),
 	'name' => $block->key(),
 	'placeholder' => $block->placeholder()->or(" "),


### PR DESCRIPTION
Using the [navigation option](https://getkirby.com/docs/reference/panel/blueprints/page#navigation-option) we can make sure the arrows use the same sorting as the pages section in the "Submissions" tab. Setting `status` to `all` includes the unlisted and draft (spam) submissions.