### PR TITLE
Fix common-fields translation

### DIFF
--- a/classes/Fields/Field.php
+++ b/classes/Fields/Field.php
@@ -148,7 +148,7 @@ abstract class Field
 	 */
 	public static function group(): string
 	{
-		return 'common';
+		return 'common-fields';
 	}
 
 	/**


### PR DESCRIPTION
You use `common-fields` and `advanced-fields` as group names and translations. The default field however returns `common` instead if `common-fields`. That's why the translation didn't work and it just said "Common".