### PR TITLE
Add null guards in pages blueprints for Kirby::user()

### DIFF
--- a/blueprints/pages/form.php
+++ b/blueprints/pages/form.php
@@ -48,7 +48,7 @@ return function () {
 					'actions' => 'dreamform/fields/actions'
 				]
 			],
-			'submissions' => App::instance()->user()->role()->permissions()->for('tobimori.dreamform', 'accessSubmissions') ? 'dreamform/tabs/form-submissions' : false,
+			'submissions' => App::instance()->user()?->role()->permissions()->for('tobimori.dreamform', 'accessSubmissions') ? 'dreamform/tabs/form-submissions' : false,
 			'settings' => [
 				'label' => 'dreamform.settings',
 				'icon' => 'cog',

--- a/blueprints/pages/forms.php
+++ b/blueprints/pages/forms.php
@@ -42,7 +42,7 @@ return function () {
 					]
 				]
 			],
-			'submissions' => App::instance()->user()->role()->permissions()->for('tobimori.dreamform', 'accessSubmissions') ? [
+			'submissions' => App::instance()->user()?->role()->permissions()->for('tobimori.dreamform', 'accessSubmissions') ? [
 				'label' => 'dreamform.submissions.recent',
 				'icon' => 'archive',
 				'sections' => [


### PR DESCRIPTION
Adding two guards against null values for `Kirby::user`. Otherwise the site will crash when no user is logged in and and form or forms page blueprint object is created. 