### PR TITLE
Add Null guards for $attr array in snippets

### DIFF
--- a/snippets/fields/button.php
+++ b/snippets/fields/button.php
@@ -25,7 +25,7 @@ if (
 
 snippet('dreamform/fields/partials/wrapper', compact('block', 'field', 'form', 'attr'), slots: true) ?>
 
-<button <?= attr(A::merge($attr['button'], [
+<button <?= attr(A::merge($attr['button'] ?? [], [
 	'type' => 'submit',
 	'hx-disabled-elt' => Htmx::isActive() ? 'this' : null
 ])) ?>>

--- a/snippets/fields/checkbox.php
+++ b/snippets/fields/checkbox.php
@@ -19,7 +19,7 @@ if (!is_array($previousValue)) {
 	$previousValue = [$previousValue];
 }
 
-$attr = A::merge($attr, $attr[$type]);
+$attr = A::merge($attr, $attr[$type] ?? []);
 snippet('dreamform/fields/partials/wrapper', $arguments = compact('block', 'field', 'form', 'attr'), slots: true);
 
 if ($block->label()->isNotEmpty()) {

--- a/snippets/fields/email.php
+++ b/snippets/fields/email.php
@@ -15,6 +15,6 @@ snippet('dreamform/fields/text', [
 	'block' => $block,
 	'form' => $form,
 	'field' => $field,
-	'attr' => A::merge($attr, $attr['input']),
+	'attr' => A::merge($attr, $attr['input'] ?? []),
 	'type' => 'email'
 ]);

--- a/snippets/fields/hidden.php
+++ b/snippets/fields/hidden.php
@@ -11,9 +11,9 @@
 
 use Kirby\Toolkit\A;
 
-$attr = A::merge($attr, $attr['hidden']); ?>
+$attr = A::merge($attr, $attr['hidden'] ?? []); ?>
 
-<input <?= attr(A::merge($attr['input'], [
+<input <?= attr(A::merge($attr['input'] ?? [], [
 	'type' => 'hidden',
 	'id' => $form->elementId($block->id()),
 	'name' => $block->key(),

--- a/snippets/fields/partials/error.php
+++ b/snippets/fields/partials/error.php
@@ -13,4 +13,4 @@ use Kirby\Toolkit\A;
 
 ?>
 
-<span <?= attr(A::merge($attr['error'], ['data-error' => $block->key()])) ?>><?= $submission?->errorFor($block->key(), $form) ?></span>
+<span <?= attr(A::merge($attr['error'] ?? [], ['data-error' => $block->key()])) ?>><?= $submission?->errorFor($block->key(), $form) ?></span>

--- a/snippets/fields/partials/label.php
+++ b/snippets/fields/partials/label.php
@@ -13,7 +13,7 @@ use Kirby\Toolkit\A;
 
 ?>
 
-<label <?= attr(A::merge($attr['label'], ["for" => $form->elementId($block->id())])) ?>>
+<label <?= attr(A::merge($attr['label'] ?? [], ["for" => $form->elementId($block->id())])) ?>>
 	<span><?= $block->label()->escape() ?></span>
 	<?php if ($required = $block->required()->toBool()) : ?>
 		<em>*</em>

--- a/snippets/fields/partials/wrapper.php
+++ b/snippets/fields/partials/wrapper.php
@@ -13,6 +13,6 @@ use Kirby\Toolkit\A;
 
 ?>
 
-<div <?= attr(A::merge($attr['field'], ['data-has-error' => !!$submission?->errorFor($block->key(), $form)])) ?>>
+<div <?= attr(A::merge($attr['field'] ?? [], ['data-has-error' => !!$submission?->errorFor($block->key(), $form)])) ?>>
 	<?= $slot ?>
 </div>

--- a/snippets/fields/select.php
+++ b/snippets/fields/select.php
@@ -12,11 +12,11 @@
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Escape;
 
-$attr = A::merge($attr, $attr['select']);
+$attr = A::merge($attr, $attr['select'] ?? []);
 snippet('dreamform/fields/partials/wrapper', $arguments = compact('block', 'field', 'form', 'attr'), slots: true);
 snippet('dreamform/fields/partials/label', $arguments); ?>
 
-<select <?= attr(A::merge($attr['input'], [
+<select <?= attr(A::merge($attr['input'] ?? [], [
 	'id' => $form->elementId($block->id()),
 	'name' => $block->key(),
 	'required' => $required ?? null,

--- a/snippets/fields/text.php
+++ b/snippets/fields/text.php
@@ -16,11 +16,11 @@ use Kirby\Toolkit\A;
 
 $type ??= 'text';
 
-$attr = A::merge($attr, $attr[$type]);
+$attr = A::merge($attr, $attr[$type] ?? []);
 snippet('dreamform/fields/partials/wrapper', $arguments = compact('block', 'field', 'form', 'attr'), slots: true);
 snippet('dreamform/fields/partials/label', $arguments); ?>
 
-<input <?= attr(A::merge($attr['input'], [
+<input <?= attr(A::merge($attr['input'] ?? [], [
 	'type' => $type,
 	'id' => $form->elementId($block->id()),
 	'name' => $block->key(),

--- a/snippets/fields/textarea.php
+++ b/snippets/fields/textarea.php
@@ -11,11 +11,11 @@
 
 use Kirby\Toolkit\A;
 
-$attr = A::merge($attr, $attr['textarea']);
+$attr = A::merge($attr, $attr['textarea'] ?? []);
 snippet('dreamform/fields/partials/wrapper', $arguments = compact('block', 'field', 'form', 'attr'), slots: true);
 snippet('dreamform/fields/partials/label', $arguments); ?>
 
-<textarea <?= attr(A::merge($attr['input'], [
+<textarea <?= attr(A::merge($attr['input'] ?? [], [
 	'id' => $form->elementId($block->id()),
 	'name' => $block->key(),
 	'placeholder' => $block->placeholder()->or(" "),

--- a/snippets/inactive.php
+++ b/snippets/inactive.php
@@ -9,6 +9,6 @@
 
 ?>
 
-<div <?= attr($attr['inactive']) ?>>
+<div <?= attr($attr['inactive'] ?? []) ?>>
 	<?= t('dreamform.form.inactiveMessage.default') ?>
 </div>

--- a/snippets/success.php
+++ b/snippets/success.php
@@ -12,6 +12,6 @@ use Kirby\Toolkit\A;
 
 ?>
 
-<div <?= attr(A::merge($attr['success'], ['id' => $form->elementId()])) ?>>
+<div <?= attr(A::merge($attr['success'] ?? [], ['id' => $form->elementId()])) ?>>
 	<?= $form->successMessage()->or(t('dreamform.form.successMessage.default')) ?>
 </div>


### PR DESCRIPTION
Adds null guards when using `$attr['some-key']` for Dreamform snippets. 

**Fixes:**
When creating a custom `dreamform/form` snippet and not setting every `$attr` array key that is referenced by a dreamform field-, partial-, success- or error-snippet, rendering the form will crash with an uncaught `Undefined array key "some-key"`.

Should’ve gotten all of them but better check again if i’ve missed on in the snippets.

