### PR TITLE
Show required asterisk if the field is required or the min field is equal or greater than 1

### DIFF
--- a/snippets/fields/partials/label.php
+++ b/snippets/fields/partials/label.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\A;
 
 <label <?= attr(A::merge($attr['label'] ?? [], ["for" => $form->elementId($block->id())])) ?>>
 	<span><?= $block->label()->escape() ?></span>
-	<?php if ($required = $block->required()->toBool()) : ?>
+	<?php if ($required = $block->required()->toBool() or $block->min() >= '1') : ?>
 		<em aria-hidden="true">*</em>
 	<?php endif ?>
 </label>

--- a/snippets/fields/partials/label.php
+++ b/snippets/fields/partials/label.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\A;
 
 <label <?= attr(A::merge($attr['label'] ?? [], ["for" => $form->elementId($block->id())])) ?>>
 	<span><?= $block->label()->escape() ?></span>
-	<?php if ($required = $block->required()->toBool() or $block->min() >= '1') : ?>
+	<?php if ($required = $block->required()->toBool() || $block->min() >= '1') : ?>
 		<em aria-hidden="true">*</em>
 	<?php endif ?>
 </label>


### PR DESCRIPTION
Fixes a bug where the required asterisk did not appear on the checkbox field label due to the checkbox field using a minimum field to determine if the checkbox was required or not