### PR TITLE
Make blueprints of LoopsAction public

### DIFF
--- a/classes/Actions/LoopsAction.php
+++ b/classes/Actions/LoopsAction.php
@@ -120,7 +120,7 @@ class LoopsAction extends Action
 		);
 	}
 
-	protected static function getFieldsBlueprint(): array
+	public static function getFieldsBlueprint(): array
 	{
 		$fields = [
 			'email' => [


### PR DESCRIPTION
Makes `LoopsAction::getFieldsBlueprint()` to allow accessing it from outside the class.