### PR TITLE
update MailchimpAction to get all lists

### DIFF
--- a/classes/Actions/MailchimpAction.php
+++ b/classes/Actions/MailchimpAction.php
@@ -159,7 +159,7 @@ class MailchimpAction extends Action
 	{
 		return static::cache(
 			'lists',
-			fn () => static::request('GET', '/lists')?->json()
+			fn () => static::request('GET', '/lists?count=1000&fields=lists.id,lists.name')?->json()
 		)['lists'];
 	}
 


### PR DESCRIPTION
Updates the subscriber list retrieval to 
- get all lists (1000 is the maximum allowed) instead of the default 10
- and to only retrieve the fields required by dreamform (id and name)

Retrieving only the fields required by the actions makes the request notably faster for bigger collections.

Documentation for `/lists` can be found here https://mailchimp.com/developer/marketing/api/lists/

