### PR TITLE
fix: add required attribute to textarea tag

### DIFF
--- a/snippets/fields/textarea.php
+++ b/snippets/fields/textarea.php
@@ -21,7 +21,7 @@ snippet('dreamform/fields/partials/label', $arguments); ?>
 		'id' => $form->elementId($block->id()),
 		'name' => $block->key(),
 		'placeholder' => $block->placeholder()->or(" "),
-		'required' => $required ?? null,
+		'required' => $block->required()->toBool() ?? null,
 		'aria-invalid' => ($error = $submission?->errorFor($block->key(), $form)) ? true : null,
 		'aria-describedby' => $error ? $form->elementId("{$block->id()}/error") : null,
 	],


### PR DESCRIPTION
When marking a multi-line text field as required, the `<textarea>` tag did not reflect this requirement.

I changed it this way locally and it worked. I don’t know if not using the `$required` variable has any implications, but the `text.php` snippet looks the same in that regard.