### PR TITLE
fix: add App namespace for Kirby\Cms\App in email templates

### DIFF
--- a/templates/emails/dreamform.html.php
+++ b/templates/emails/dreamform.html.php
@@ -1,4 +1,4 @@
-<!doctype html>
+<?php use Kirby\Cms\App; ?><!doctype html>
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>

--- a/templates/emails/dreamform.php
+++ b/templates/emails/dreamform.php
@@ -1,4 +1,4 @@
-<?= tt('dreamform.actions.email.defaultTemplate.text', null, ['form' => $form->title()]) ?>
+<?php use Kirby\Cms\App; ?><?= tt('dreamform.actions.email.defaultTemplate.text', null, ['form' => $form->title()]) ?>
 
 
 ———


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Internal improvements to email templates for better maintainability. No visible changes to email content or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->