### PR TITLE
fix(brevo): allow updating the existing contact

### DIFF
--- a/classes/Actions/BrevoAction.php
+++ b/classes/Actions/BrevoAction.php
@@ -158,6 +158,7 @@ class BrevoAction extends Action
 			($doubleOptIn ? 'includeListIds' : 'listIds') => [intval(Str::replace($list, 'id-', ''))],
 			'templateId' => $doubleOptIn ? intval(Str::replace($this->block()->doubleOptInTemplate()->value(), 'id-', '')) : null,
 			'redirectionUrl' => $doubleOptIn ? $this->block()->doubleOptInRedirect()->toUrl() : null,
+			'updateEnabled' => true,
 		]);
 
 		if ($request->code() > 299) {


### PR DESCRIPTION
Hi @tobimori,

I’m submitting a merge request for the Brevo integration — by the way, thank you so much for adding this action! It’s been great to work with.

Currently, when submitting a form with the Brevo integration, if a contact with the provided email already exists, the contact creation fails with the error message:

> Unable to create contact, email is already associated with another Contact.

I suggest modifying the behavior to allow updating an existing contact instead. This would enable adding the contact to different lists or updating other attributes (like name, etc.).

The `updateEnabled` param is documented in the corresponding [Brevo docs](https://developers.brevo.com/reference/createcontact).

Looking forward to your feedback!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved contact update synchronization with the Brevo integration to properly enable contact updates when subscribing to or updating contact records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->