### PR TITLE
fix(email): pass attachments to beforeSend closure

### DIFF
--- a/classes/Actions/EmailAction.php
+++ b/classes/Actions/EmailAction.php
@@ -205,6 +205,8 @@ class EmailAction extends Action
 	public function run(): void
 	{
 		try {
+			// get attachments before email is created
+			$attachments = $this->attachments();
 
 			$email = App::instance()->email([
 				'template' => $this->template(),
@@ -220,9 +222,9 @@ class EmailAction extends Action
 					'form' => $this->submission()->form(),
 				],
 				'attachments' => [], // don't pass attachments here, add them in beforeSend
-				'beforeSend' => function ($mailer) {
+				'beforeSend' => function ($mailer) use ($attachments) { // pass attachments to closure otherwise this->attachments() won't work
 					// add attachments with custom names
-					foreach ($this->attachments() as $attachment) {
+					foreach ($attachments as $attachment) {
 						if (is_array($attachment)) {
 							$mailer->addAttachment($attachment['path'], $attachment['name']);
 						} else {
@@ -264,7 +266,7 @@ class EmailAction extends Action
 					$attachments[] = $file;
 				}
 			} else { // is PHP file object
-				$files = array_values(A::filter($value->value(), fn ($file) => $file['error'] === UPLOAD_ERR_OK));
+				$files = array_values(A::filter($value->value(), fn($file) => $file['error'] === UPLOAD_ERR_OK));
 				foreach ($files as $file) {
 					$attachments[] = [
 						'path' => $file['tmp_name'],

--- a/classes/Actions/EmailAction.php
+++ b/classes/Actions/EmailAction.php
@@ -221,8 +221,8 @@ class EmailAction extends Action
 					'submission' => $this->submission(),
 					'form' => $this->submission()->form(),
 				],
-				'attachments' => [], // don't pass attachments here, add them in beforeSend
-				'beforeSend' => function ($mailer) use ($attachments) { // pass attachments to closure otherwise this->attachments() won't work
+				'attachments' => [], // attachments added in beforeSend for custom naming
+				'beforeSend' => function ($mailer) use ($attachments) { // use captured attachments to ensure files are accessed at the correct time
 					// add attachments with custom names
 					foreach ($attachments as $attachment) {
 						if (is_array($attachment)) {


### PR DESCRIPTION
Attachments are now passed explicitly to the beforeSend callback instead of relying on $this inside the closure, ensuring proper scope.

Fix https://github.com/tobimori/kirby-dreamform/issues/148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed email attachment handling so files included with outgoing emails are reliably attached and processed at send time; custom file naming is now preserved and missing attachments are avoided, improving delivery consistency and reducing failed or incomplete emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->