### PR TITLE
fix: add type check before file UUID string operation

### DIFF
--- a/classes/Actions/EmailAction.php
+++ b/classes/Actions/EmailAction.php
@@ -266,7 +266,7 @@ class EmailAction extends Action
 		foreach ($this->block()->attachments()->split() as $id) {
 			$value = $this->submission()->valueForId($id);
 
-			if (Str::contains($value->value(), 'file://')) { // is a file uuid
+			if (is_string($value->value()) && Str::contains($value->value(), 'file://')) { // is a file uuid
 				$files = $value->toFiles();
 				foreach ($files as $file) {
 					$attachments[] = $file;


### PR DESCRIPTION
Hey @tobimori! Got some errors when the `value` field contains an array, because `Str::contains` requires a string or null as first param.  

Changes: Add is_string() check before calling Str::contains() to prevent errors when value is not a string type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced email attachment processing with improved type validation to ensure more reliable handling of attachments across various scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->