### PR TITLE
fix: normalize www. prefix in license URL even without protocol

### DIFF
--- a/classes/Support/License.php
+++ b/classes/Support/License.php
@@ -193,7 +193,7 @@ final class License extends KirbyLicense
 	public static function normalizeUrl(string $url): string
 	{
 		return preg_replace(
-			'/^https?:\/\/(?:www\.|staging\.|test\.|dev\.)?|\/$/',
+			'/^(?:https?:\/\/)?(?:www\.|staging\.|test\.|dev\.)?|\/$/',
 			'',
 			$url
 		);


### PR DESCRIPTION
The normalizeUrl regex required a protocol (http:// or https://) to be
present before it would strip subdomain prefixes like www. If the
assignedUrl in the license file was stored without a protocol (e.g.
www.example.com), the www. prefix was not stripped, causing a domain
mismatch when compared against the current site URL.

https://claude.ai/code/session_01Emo9AcSNEKZxbQc3bKvdjG